### PR TITLE
feat: AI 기반 결제 이상 탐지 에이전트 시스템 (incident-detector/agent/api) 및 운영자 대시보드 테스트

### DIFF
--- a/incident-detector/src/main/java/com/example/incident/detector/rules/DuplicatePaymentRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/DuplicatePaymentRule.java
@@ -53,6 +53,19 @@ public class DuplicatePaymentRule {
             return;
         }
 
+        Long userId = null, concertId = null, scheduleId = null;
+        if (event.payloadJson() != null) {
+            try {
+                com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(event.payloadJson());
+                if (!node.path("userId").isMissingNode() && !node.path("userId").isNull())
+                    userId = node.path("userId").asLong();
+                if (!node.path("concertId").isMissingNode() && !node.path("concertId").isNull())
+                    concertId = node.path("concertId").asLong();
+                if (!node.path("scheduleId").isMissingNode() && !node.path("scheduleId").isNull())
+                    scheduleId = node.path("scheduleId").asLong();
+            } catch (Exception ignored) {}
+        }
+
         IncidentCreateCommand cmd = new IncidentCreateCommand(
                 "DUPLICATE_PAYMENT",
                 incidentKey,
@@ -61,7 +74,7 @@ public class DuplicatePaymentRule {
                 buildStateJson(event),
                 event.paymentId(),
                 event.bookingId(),
-                null, null, null
+                userId, concertId, scheduleId
         );
 
         incidentWriteService.createOrUpdate(cmd);

--- a/incident-detector/src/main/java/com/example/incident/detector/rules/GhostOrderRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/GhostOrderRule.java
@@ -96,6 +96,9 @@ public class GhostOrderRule {
      */
     public void raiseIncidentFromExpired(PendingCorrelation pending) {
         UUID paymentId = extractUuidFromExtraJson(pending.getExtraJsonb(), "paymentId");
+        Long userId    = extractLongFromExtraJson(pending.getExtraJsonb(), "userId");
+        Long concertId = extractLongFromExtraJson(pending.getExtraJsonb(), "concertId");
+        Long scheduleId = extractLongFromExtraJson(pending.getExtraJsonb(), "scheduleId");
         IncidentCreateCommand cmd = new IncidentCreateCommand(
                 "GHOST_ORDER",
                 pending.getKeyValue(),
@@ -104,7 +107,7 @@ public class GhostOrderRule {
                 buildCurrentStateJson(pending),
                 paymentId,
                 UUID.fromString(pending.getKeyValue()),
-                null, null, null
+                userId, concertId, scheduleId
         );
         incidentWriteService.createOrUpdate(cmd);
         log.info("[ghost-order] Incident created from expired correlation. bookingId={}", pending.getKeyValue());
@@ -112,10 +115,26 @@ public class GhostOrderRule {
 
     private String buildExtraJson(PaymentEventMessage event) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "paymentId", String.valueOf(event.paymentId()),
-                    "occurredAt", orEmpty(event.occurredAt())
-            ));
+            // payloadJson에서 userId/concertId/scheduleId 추출 후 extraJsonb에 함께 저장
+            Long userId = null, concertId = null, scheduleId = null;
+            if (event.payloadJson() != null) {
+                try {
+                    com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(event.payloadJson());
+                    if (!node.path("userId").isMissingNode() && !node.path("userId").isNull())
+                        userId = node.path("userId").asLong();
+                    if (!node.path("concertId").isMissingNode() && !node.path("concertId").isNull())
+                        concertId = node.path("concertId").asLong();
+                    if (!node.path("scheduleId").isMissingNode() && !node.path("scheduleId").isNull())
+                        scheduleId = node.path("scheduleId").asLong();
+                } catch (Exception ignored) {}
+            }
+            java.util.LinkedHashMap<String, Object> map = new java.util.LinkedHashMap<>();
+            map.put("paymentId", String.valueOf(event.paymentId()));
+            map.put("occurredAt", orEmpty(event.occurredAt()));
+            if (userId != null)    map.put("userId", userId);
+            if (concertId != null) map.put("concertId", concertId);
+            if (scheduleId != null) map.put("scheduleId", scheduleId);
+            return objectMapper.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             return "{}";
         }
@@ -139,15 +158,27 @@ public class GhostOrderRule {
     }
 
     private UUID extractUuidFromExtraJson(String extraJson, String key) {
-        if (extraJson == null || extraJson.isBlank()) {
-            return null;
-        }
+        if (extraJson == null || extraJson.isBlank()) return null;
         try {
-            Map<String, String> parsed = objectMapper.readValue(extraJson, new TypeReference<>() {});
-            String value = parsed.get(key);
-            return value != null && !value.isBlank() ? UUID.fromString(value) : null;
+            Map<String, Object> parsed = objectMapper.readValue(extraJson, new TypeReference<>() {});
+            Object value = parsed.get(key);
+            if (value == null) return null;
+            return UUID.fromString(value.toString());
         } catch (Exception e) {
             log.debug("[ghost-order] Failed to parse extraJson for key={}", key, e);
+            return null;
+        }
+    }
+
+    private Long extractLongFromExtraJson(String extraJson, String key) {
+        if (extraJson == null || extraJson.isBlank()) return null;
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(extraJson, new TypeReference<>() {});
+            Object value = parsed.get(key);
+            if (value == null) return null;
+            return Long.parseLong(value.toString());
+        } catch (Exception e) {
+            log.debug("[ghost-order] Failed to parse extraJson for key={}, error={}", key, e.getMessage());
             return null;
         }
     }

--- a/incident-detector/src/main/java/com/example/incident/detector/rules/UnconfirmedPaymentRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/UnconfirmedPaymentRule.java
@@ -69,7 +69,10 @@ public class UnconfirmedPaymentRule {
      * PendingCorrelationCheckScheduler에서 호출: deadline 초과된 미해결 건을 incident로 전환
      */
     public void raiseIncidentFromExpired(PendingCorrelation pending) {
-        UUID bookingId = extractUuidFromExtraJson(pending.getExtraJsonb(), "bookingId");
+        UUID bookingId   = extractUuidFromExtraJson(pending.getExtraJsonb(), "bookingId");
+        Long userId      = extractLongFromExtraJson(pending.getExtraJsonb(), "userId");
+        Long concertId   = extractLongFromExtraJson(pending.getExtraJsonb(), "concertId");
+        Long scheduleId  = extractLongFromExtraJson(pending.getExtraJsonb(), "scheduleId");
         IncidentCreateCommand cmd = new IncidentCreateCommand(
                 "UNCONFIRMED_PAYMENT",
                 pending.getKeyValue(),
@@ -78,7 +81,7 @@ public class UnconfirmedPaymentRule {
                 buildCurrentStateJson(pending),
                 UUID.fromString(pending.getKeyValue()),
                 bookingId,
-                null, null, null
+                userId, concertId, scheduleId
         );
         incidentWriteService.createOrUpdate(cmd);
         log.info("[unconfirmed-payment] Incident created from expired correlation. paymentId={}", pending.getKeyValue());
@@ -121,14 +124,41 @@ public class UnconfirmedPaymentRule {
 
     private String buildExtraJson(PaymentEventMessage event) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "bookingId", String.valueOf(event.bookingId()),
-                    "fromStatus", orEmpty(event.fromStatus()),
-                    "toStatus", orEmpty(event.toStatus()),
-                    "occurredAt", orEmpty(event.occurredAt())
-            ));
+            Long userId = null, concertId = null, scheduleId = null;
+            if (event.payloadJson() != null) {
+                try {
+                    com.fasterxml.jackson.databind.JsonNode node = objectMapper.readTree(event.payloadJson());
+                    if (!node.path("userId").isMissingNode() && !node.path("userId").isNull())
+                        userId = node.path("userId").asLong();
+                    if (!node.path("concertId").isMissingNode() && !node.path("concertId").isNull())
+                        concertId = node.path("concertId").asLong();
+                    if (!node.path("scheduleId").isMissingNode() && !node.path("scheduleId").isNull())
+                        scheduleId = node.path("scheduleId").asLong();
+                } catch (Exception ignored) {}
+            }
+            java.util.LinkedHashMap<String, Object> map = new java.util.LinkedHashMap<>();
+            map.put("bookingId", String.valueOf(event.bookingId()));
+            map.put("fromStatus", orEmpty(event.fromStatus()));
+            map.put("toStatus", orEmpty(event.toStatus()));
+            map.put("occurredAt", orEmpty(event.occurredAt()));
+            if (userId != null)     map.put("userId", userId);
+            if (concertId != null)  map.put("concertId", concertId);
+            if (scheduleId != null) map.put("scheduleId", scheduleId);
+            return objectMapper.writeValueAsString(map);
         } catch (JsonProcessingException e) {
             return "{}";
+        }
+    }
+
+    private Long extractLongFromExtraJson(String extraJson, String key) {
+        if (extraJson == null || extraJson.isBlank()) return null;
+        try {
+            Map<String, Object> parsed = objectMapper.readValue(extraJson, new TypeReference<>() {});
+            Object value = parsed.get(key);
+            if (value == null) return null;
+            return Long.parseLong(value.toString());
+        } catch (Exception e) {
+            return null;
         }
     }
 


### PR DESCRIPTION
## 📌 관련 기능
<!-- 아래 중 하나 선택 후 나머지는 지워주세요 -->
- [ ] 소셜 기능
- [ ] 좌석 선택
- [ ] 대기열
- [ ] 결제
- [X] AI Agent

---

## 🔗 관련 이슈
<!-- 연결된 이슈 번호 작성 (예: #12) -->
Closes #21 

---

## 📝 작업 내용
<!-- 무엇을 구현/수정했는지 간단히 작성 -->
## Summary

- **incident-detector**: Kafka 이벤트 소비 → 4가지 이상 패턴 실시간 탐지
- **incident-agent**: GPT-4o 기반 자동 원인 분석 및 심각도 평가
- **incident-api**: 운영자 대시보드 REST API + 프론트엔드 UI
- **K8s 배포**: EKS fairline 네임스페이스에 3개 서비스 완전 배포 완료

## 탐지 케이스 (4종)

| 유형 | 탐지 방식 | 심각도 |
|------|-----------|--------|
| `DUPLICATE_PAYMENT` | 동일 bookingId로 PAYMENT_CONFIRMED 2회 이상 수신 | high |
| `GHOST_ORDER` | PAYMENT_CONFIRMED 후 N분 내 booking.confirmed 미수신 | high |
| `UNCONFIRMED_PAYMENT` | PAYMENT_PAID 후 N분 내 PAYMENT_CONFIRMED 미수신 | medium |
| `ZOMBIE_HOLD` | 예약 취소 후 Redis 좌석 점유 키 미해제 | medium |

## 주요 변경 사항

### incident-detector
- `PaymentEventConsumer` / `TicketingEventConsumer`: Kafka 이벤트 소비 + Inbox 패턴 중복 방지
- `DuplicatePaymentRule`: Redis 기반 첫 확인 마킹, 중복 시 인시던트 즉시 생성
- `GhostOrderRule` / `UnconfirmedPaymentRule`: `PendingCorrelation` 등록 → 스케줄러 만료 감지
- `ZombieHoldRule` + `ZombieHoldCheckScheduler`: Redis 키 잔존 여부 주기적 스캔
- `PendingCorrelationCheckScheduler`: deadline 초과 미해결 건 자동 인시던트 전환
- **fix**: `payloadJson`에서 `userId`/`concertId`/`scheduleId` 추출하여 인시던트에 저장

### incident-agent
- `AnalysisJobScheduler`: PENDING 인시던트 주기적 폴링 → LLM 분석 파이프라인 실행
- `OpenAiLlmClient`: GPT-4o 호출, JSON 스키마 검증, 재시도 처리
- `AnalysisOutputValidator`: 분석 결과 스키마 검증 및 신뢰도 평가

### incident-api
- `IncidentController`: 목록 조회 / 상세 조회 / 상태 전환 / 재분석 요청 REST API
- 운영자 대시보드 프론트엔드: `OpsIncidentListPage.vue`, `OpsIncidentDetailPage.vue`

### 인프라
- `fairline_k8s/incident-*/`: deployment / service / configmap 매니페스트 추가
- `ingress.yaml`: `/ops/incidents` 경로 추가 (외부 노출)
- 포트 수정: 8080 → 18086/18087/18088 (실제 애플리케이션 포트에 맞게 정정)

### 문서
- `yewon/docs/incident-agent-visualization-v3.html`: 전체 아키텍처 시각화
- `agent/README.md`: 에이전트 시스템 설명

## Test Plan

- [x] DUPLICATE_PAYMENT: 동일 bookingId로 PAYMENT_CONFIRMED 2회 발행 → 인시던트 생성 확인
- [x] GHOST_ORDER: PAYMENT_CONFIRMED 발행 후 booking.confirmed 미발행 → 5분 후 탐지 확인
- [x] UNCONFIRMED_PAYMENT: PAYMENT_PAID 발행 후 PAYMENT_CONFIRMED 미발행 → 2분 후 탐지 확인
- [x] ZOMBIE_HOLD: 예약 취소 + Redis 키 주입 → 60초 후 탐지 확인
- [x] 모든 인시던트 GPT-4o 분석 COMPLETED (confidence ≥ 0.9)
- [x] 운영자 대시보드 `userId`/`concertId`/`scheduleId` 정상 표시
- [x] 외부 접속: `https://skala3-cloud1-team4.cloud.skala-ai.com/ops/incidents` 200 OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## 💻 작업 범위
<!-- 해당되는 항목 체크 -->
- [ ] Front (Vue)
- [ ] Back (Spring)
- [ ] Infra

---

## ✅ 테스트 확인 (선택)
<!-- 확인한 항목 체크 -->

- [ ] 정상 동작 확인
- [ ] 콘솔 에러 없음
- [ ] API 응답 정상
- [ ] 예외 케이스 테스트

---

## 📎 참고 사항 (선택)
<!-- 스크린샷, API 명세 변경 사항, DB 변경 사항 등 -->
