### PR TITLE
feat: 결제 운영 대시보드 라이트 테마 적용 및 목업 추가

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,18 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "ops-dashboard-mockup",
+      "runtimeExecutable": "npx",
+      "runtimeArgs": ["serve", "-p", "5500", "yewon"],
+      "port": 5500
+    },
+    {
+      "name": "frontend-dev",
+      "runtimeExecutable": "bash",
+      "runtimeArgs": ["-c", "cd /Users/yangyewon/workspace/SKALA-Mini-Project-2/frontend && npx vite"],
+      "port": 5173,
+      "autoPort": true
+    }
+  ]
+}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -328,21 +328,36 @@ onUnmounted(() => {
 </script>
 
 <template>
-  <!-- 운영자 대시보드: 별도 다크 레이아웃 -->
-  <div v-if="normalizedPath === '/ops'" class="min-h-screen" style="background:#081326; color:#e2eaf4;">
-    <header class="sticky top-0 z-50 border-b" style="border-color:#1e3553; background:#081326;">
-      <div class="mx-auto max-w-[1440px] flex items-center justify-between px-6 py-3">
+  <!-- 운영자 대시보드: 라이트 레이아웃 -->
+  <div v-if="normalizedPath === '/ops'" class="min-h-screen" style="background:radial-gradient(circle at 8% 0%, #f7fbff 0%, #edf4fc 35%, #f3f7fc 100%); color:#173451;">
+    <!-- utility bar -->
+    <div style="background:#f7fafd; border-bottom:1px solid #dfe7f0;">
+      <div class="mx-auto max-w-[1280px] flex justify-end gap-4 px-6 py-2 text-xs" style="color:#4f6480;">
+        <button class="hover:underline bg-transparent border-none cursor-pointer font-[inherit] text-xs" style="color:#4f6480;" @click="navigate('/main')">← 서비스로</button>
+        <span style="color:#c8d5e2;">|</span>
+        <span style="color:#ff7a00; font-weight:700;">운영 대시보드</span>
+      </div>
+    </div>
+    <!-- logo row -->
+    <header class="sticky top-0 z-50 border-b" style="border-color:#d8e2ef; background:rgba(255,255,255,.95); backdrop-filter:blur(6px);">
+      <div class="mx-auto max-w-[1280px] flex items-center justify-between px-6 py-3">
         <div class="flex items-center gap-3">
-          <span class="text-base font-extrabold tracking-tight" style="color:#ff7a00;">🎫 FairlineTicket</span>
-          <span style="color:#1e3553;">/</span>
-          <span class="text-sm font-semibold" style="color:#7a9ab8;">결제 운영 대시보드</span>
+          <img src="/fairline_ticket_favicon.jpg" alt="FairlineTicket" class="h-10 w-auto object-contain rounded-lg" />
+          <span class="text-lg font-extrabold tracking-tight" style="color:#ff7a00;">FairlineTicket</span>
+          <span style="color:#d8e2ef;">/</span>
+          <span class="text-sm font-semibold" style="color:#4f6480;">결제 운영 대시보드</span>
         </div>
-        <button class="text-sm px-3 py-1 rounded-lg" style="border:1px solid #1e3553; color:#e2eaf4;" @click="navigate('/main')">
-          ← 서비스로
-        </button>
+      </div>
+      <!-- nav -->
+      <div style="border-top:1px solid #e0e7f0;">
+        <div class="mx-auto max-w-[1280px] px-6 flex gap-1">
+          <button class="border-b-2 px-5 py-3 text-sm font-bold" style="border-color:transparent; color:#2c4764; background:none; cursor:pointer; font-family:inherit;" @click="navigate('/main')">메인</button>
+          <button class="border-b-2 px-5 py-3 text-sm font-bold" style="border-color:transparent; color:#2c4764; background:none; cursor:pointer; font-family:inherit;" @click="navigate('/concerts')">콘서트</button>
+          <button class="border-b-2 px-5 py-3 text-sm font-bold" style="border-color:#ff7a00; color:#ff7a00; background:none; cursor:pointer; font-family:inherit;">운영 대시보드</button>
+        </div>
       </div>
     </header>
-    <main class="mx-auto max-w-[1440px] px-6 py-8">
+    <main class="mx-auto max-w-[1280px] px-6 py-8">
       <OpsIncidentDetailPage
         v-if="opsIncidentId"
         :incident-id="opsIncidentId"

--- a/frontend/src/components/ops/OpsIncidentDetailPage.vue
+++ b/frontend/src/components/ops/OpsIncidentDetailPage.vue
@@ -473,133 +473,133 @@ function confidencePct(v: AnalysisVersion | null): number {
 </template>
 
 <style scoped>
-.detail-wrap { display: flex; flex-direction: column; gap: 16px; color: #e2eaf4; }
+.detail-wrap { display: flex; flex-direction: column; gap: 20px; color: #173451; }
 
 .back-btn {
-  background: none; border: none; color: #7a9ab8;
-  font-size: 13px; cursor: pointer; padding: 0; width: fit-content;
+  background: none; border: none; color: #4f6480;
+  font-size: 13px; font-weight: 600; cursor: pointer; padding: 0; width: fit-content; font-family: inherit;
 }
-.back-btn:hover { color: #e2eaf4; }
+.back-btn:hover { color: #173451; }
 
 .ops-card {
-  background: #0d1e35;
-  border: 1px solid #1e3553;
+  background: #ffffff;
+  border: 1px solid #d8e2ef;
   border-radius: 16px;
-  padding: 20px 24px;
+  padding: 24px;
 }
 
-.center-msg { text-align: center; color: #7a9ab8; padding: 32px; }
-.error-banner { color: #fca5a5; background: #450a0a; border-color: #7f1d1d; }
-.action-msg { color: #86efac; background: #052e16; border-color: #166534; cursor: pointer; font-size: 13px; }
+.center-msg { text-align: center; color: #6a819a; padding: 32px; }
+.error-banner { color: #b91c1c; background: #fef2f2; border-color: #fca5a5; }
+.action-msg { color: #15803d; background: #f0fdf4; border-color: #bbf7d0; cursor: pointer; font-size: 13px; }
 
 /* 헤더 */
 .detail-header { display: flex; align-items: flex-start; justify-content: space-between; flex-wrap: wrap; gap: 16px; }
-.header-left   { display: flex; flex-direction: column; gap: 8px; }
+.header-left   { display: flex; flex-direction: column; gap: 10px; }
 .header-badges { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; }
-.type-title    { font-size: 18px; font-weight: 800; }
-.header-meta   { display: flex; gap: 16px; font-size: 12px; flex-wrap: wrap; }
-.header-meta code { font-family: monospace; }
+.type-title    { font-size: 20px; font-weight: 800; color: #173451; }
+.header-meta   { display: flex; gap: 20px; font-size: 12px; flex-wrap: wrap; color: #6a819a; }
+.header-meta code { font-family: monospace; color: #173451; font-weight: 600; }
 .header-actions { display: flex; gap: 8px; flex-wrap: wrap; }
 
 /* 2컬럼 */
-.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.two-col { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
 @media (max-width: 960px) { .two-col { grid-template-columns: 1fr; } }
 
 .right-col { display: flex; flex-direction: column; gap: 16px; }
 
 /* 분석 카드 */
-.analysis-card { display: flex; flex-direction: column; gap: 16px; }
+.analysis-card { display: flex; flex-direction: column; gap: 18px; }
 .section-header { display: flex; align-items: center; gap: 10px; }
-.section-title  { font-weight: 700; font-size: 14px; }
+.section-title  { font-weight: 800; font-size: 15px; color: #173451; }
 
-.confidence-wrap { display: flex; flex-direction: column; gap: 4px; }
-.confidence-label { display: flex; justify-content: space-between; font-size: 12px; }
+.confidence-wrap { display: flex; flex-direction: column; gap: 6px; }
+.confidence-label { display: flex; justify-content: space-between; font-size: 12px; color: #6a819a; }
 .confidence-val  { font-weight: 700; color: #ff7a00; }
-.confidence-track { background: #1e3553; border-radius: 4px; height: 8px; overflow: hidden; }
+.confidence-track { background: #d6e3f2; border-radius: 4px; height: 7px; overflow: hidden; }
 .confidence-fill  { height: 100%; background: #ff7a00; border-radius: 4px; transition: width 0.3s; }
 
-.block-box   { background: #112040; border: 1px solid #1e3553; border-radius: 10px; padding: 12px 14px; }
-.block-label { font-size: 11px; font-weight: 600; color: #7a9ab8; margin-bottom: 4px; }
-.block-text  { font-size: 13px; line-height: 1.6; }
-.muted-light { color: #cbd5e1; font-size: 13px; line-height: 1.6; }
+.block-box   { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 12px; padding: 14px 16px; }
+.block-label { font-size: 11px; font-weight: 700; color: #6a819a; margin-bottom: 4px; }
+.block-text  { font-size: 13px; line-height: 1.6; color: #173451; }
+.muted-light { color: #4f6480; font-size: 13px; line-height: 1.6; }
 
 .action-list { list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 8px; }
-.action-item { display: flex; gap: 10px; align-items: flex-start; font-size: 13px; }
-.action-num  { background: #ff7a00; color: #fff; border-radius: 999px; min-width: 20px; height: 20px; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; flex-shrink: 0; margin-top: 1px; }
+.action-item { display: flex; gap: 10px; align-items: flex-start; font-size: 13px; color: #173451; }
+.action-num  { background: #ff7a00; color: #fff; border-radius: 999px; min-width: 22px; height: 22px; display: flex; align-items: center; justify-content: center; font-size: 11px; font-weight: 700; flex-shrink: 0; margin-top: 1px; }
 .action-title { font-weight: 600; }
 
-.approval-banner { display: flex; align-items: flex-start; gap: 12px; background: #7c2d12; border: 1px solid #f97316; border-radius: 10px; padding: 12px 14px; }
-.approval-title  { font-size: 13px; font-weight: 700; color: #fdba74; }
-.approval-sub    { font-size: 12px; color: #fcd9af; margin-top: 2px; }
+.approval-banner { display: flex; align-items: flex-start; gap: 12px; background: #fff7ed; border: 1px solid #fdba74; border-radius: 12px; padding: 14px 16px; }
+.approval-title  { font-size: 13px; font-weight: 700; color: #c2410c; }
+.approval-sub    { font-size: 12px; color: #9a3412; margin-top: 2px; }
 
 /* 스냅샷 */
-.snapshot-card, .resource-card, .analysis-status-card { padding: 18px 20px; }
-.snapshot-grid  { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 10px; }
-.snapshot-item  { background: #112040; border: 1px solid #1e3553; border-radius: 8px; padding: 8px 10px; }
-.snapshot-key   { font-size: 11px; margin-bottom: 2px; }
-.snapshot-val   { font-size: 13px; font-weight: 700; font-family: monospace; }
+.snapshot-card, .resource-card, .analysis-status-card { padding: 20px 22px; }
+.snapshot-grid  { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
+.snapshot-item  { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 10px; padding: 10px 12px; }
+.snapshot-key   { font-size: 11px; font-weight: 600; color: #6a819a; margin-bottom: 3px; }
+.snapshot-val   { font-size: 13px; font-weight: 700; font-family: monospace; color: #173451; }
 
-.resource-list { display: flex; flex-direction: column; gap: 6px; margin-top: 10px; font-size: 13px; }
+.resource-list { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; font-size: 13px; }
 .resource-row  { display: flex; justify-content: space-between; align-items: center; }
-.resource-row code { font-family: monospace; font-size: 12px; }
+.resource-row code { font-family: monospace; font-size: 12px; font-weight: 600; color: #173451; }
 
 /* 신호 */
-.signal-card  { padding: 18px 20px; }
-.signal-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
-.signal-chip  { display: inline-flex; align-items: center; background: #112040; border: 1px solid #1e3553; border-radius: 6px; padding: 4px 10px; font-size: 12px; color: #7a9ab8; }
+.signal-card  { padding: 20px 22px; }
+.signal-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.signal-chip  { display: inline-flex; align-items: center; background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 8px; padding: 4px 12px; font-size: 12px; font-weight: 600; color: #4f6480; }
 
 /* 탭 */
 .tab-card    { padding: 0; overflow: hidden; }
-.tab-bar     { display: flex; border-bottom: 1px solid #1e3553; }
-.tab-btn     { padding: 12px 20px; font-size: 13px; font-weight: 600; background: none; border: none; cursor: pointer; }
+.tab-bar     { display: flex; border-bottom: 1px solid #d6e3f2; }
+.tab-btn     { padding: 14px 24px; font-size: 13px; font-weight: 600; background: none; border: none; cursor: pointer; font-family: inherit; }
 .tab-active  { border-bottom: 2px solid #ff7a00; color: #ff7a00; margin-bottom: -1px; }
-.tab-inactive { color: #7a9ab8; }
-.tab-inactive:hover { color: #e2eaf4; }
+.tab-inactive { color: #6a819a; }
+.tab-inactive:hover { color: #173451; }
 .tab-pane    { padding: 20px 24px; display: flex; flex-direction: column; gap: 12px; }
 
-.version-row { background: #112040; border: 1px solid #1e3553; border-radius: 10px; padding: 14px 16px; }
+.version-row { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 12px; padding: 14px 16px; }
 .version-header { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 6px; }
-.version-summary { font-size: 13px; line-height: 1.5; }
-.version-failure { font-size: 12px; color: #fca5a5; margin-top: 4px; }
-.trigger-chip { background: #0d1e35; border: 1px solid #1e3553; border-radius: 4px; padding: 2px 8px; font-size: 11px; color: #7a9ab8; }
-.latest-chip  { background: #1e3a5f; color: #93c5fd; border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; }
+.version-summary { font-size: 13px; line-height: 1.5; color: #173451; }
+.version-failure { font-size: 12px; color: #b91c1c; margin-top: 4px; }
+.trigger-chip { background: #ffffff; border: 1px solid #d6e3f2; border-radius: 6px; padding: 2px 8px; font-size: 11px; color: #6a819a; }
+.latest-chip  { background: #dbeafe; color: #1e40af; border: 1px solid #bfdbfe; border-radius: 999px; padding: 2px 8px; font-size: 11px; font-weight: 600; }
 .opacity-60   { opacity: 0.65; }
 
 .history-row   { display: flex; align-items: flex-start; gap: 14px; }
-.history-item  { background: #112040; border: 1px solid #1e3553; border-radius: 10px; padding: 10px 14px; flex: 1; display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
-.history-actor { font-weight: 600; font-size: 13px; }
-.arrow         { font-size: 13px; }
-.history-note  { width: 100%; font-size: 12px; margin-top: 4px; }
-.time-cell     { font-size: 11px; white-space: nowrap; padding-top: 12px; flex-shrink: 0; min-width: 120px; }
+.history-item  { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 10px; padding: 12px 16px; flex: 1; display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+.history-actor { font-weight: 700; font-size: 13px; color: #173451; }
+.arrow         { font-size: 13px; color: #6a819a; }
+.history-note  { width: 100%; font-size: 12px; margin-top: 4px; color: #6a819a; }
+.time-cell     { font-size: 11px; white-space: nowrap; padding-top: 14px; flex-shrink: 0; min-width: 120px; color: #6a819a; font-family: monospace; }
 
 /* 배지 공통 */
-.badge { display: inline-block; padding: 3px 8px; border-radius: 999px; font-size: 11px; font-weight: 700; white-space: nowrap; }
-.badge-critical { background: #7f1d1d; color: #fca5a5; }
-.badge-high     { background: #7c2d12; color: #fdba74; }
-.badge-medium   { background: #713f12; color: #fde68a; }
-.badge-low      { background: #1e3a5f; color: #93c5fd; }
+.badge { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 11px; font-weight: 700; white-space: nowrap; }
+.badge-critical { background: #fee2e2; color: #b91c1c; border: 1px solid #fca5a5; }
+.badge-high     { background: #ffedd5; color: #c2410c; border: 1px solid #fdba74; }
+.badge-medium   { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
+.badge-low      { background: #dbeafe; color: #1d4ed8; border: 1px solid #93c5fd; }
 
-.status-badge { display: inline-block; padding: 3px 8px; border-radius: 999px; font-size: 11px; font-weight: 600; white-space: nowrap; }
-.status-open         { background: #1e3a5f; color: #93c5fd; }
-.status-analyzing    { background: #312e81; color: #c4b5fd; }
-.status-analyzed     { background: #164e63; color: #67e8f9; }
-.status-acknowledged { background: #374151; color: #d1d5db; }
-.status-resolved     { background: #14532d; color: #86efac; }
+.status-badge { display: inline-block; padding: 3px 10px; border-radius: 999px; font-size: 11px; font-weight: 600; white-space: nowrap; }
+.status-open         { background: #dbeafe; color: #1e40af; border: 1px solid #bfdbfe; }
+.status-analyzing    { background: #ede9fe; color: #6d28d9; border: 1px solid #ddd6fe; }
+.status-analyzed     { background: #cffafe; color: #0e7490; border: 1px solid #a5f3fc; }
+.status-acknowledged { background: #f1f5f9; color: #475569; border: 1px solid #cbd5e1; }
+.status-resolved     { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
 
 /* 버튼 */
 .btn-orange {
   background: #ff7a00; color: #fff; border: none;
-  border-radius: 10px; padding: 8px 16px; font-size: 13px; font-weight: 700; cursor: pointer;
+  border-radius: 10px; padding: 10px 18px; font-size: 13px; font-weight: 700; cursor: pointer; font-family: inherit;
 }
 .btn-orange:hover:not(:disabled) { background: #e86f00; }
 .btn-orange:disabled { opacity: 0.4; cursor: not-allowed; }
 
 .btn-ghost {
-  background: transparent; border: 1px solid #1e3553; color: #e2eaf4;
-  border-radius: 10px; padding: 8px 16px; font-size: 13px; font-weight: 600; cursor: pointer;
+  background: transparent; border: 1px solid #d8e2ef; color: #173451;
+  border-radius: 10px; padding: 10px 18px; font-size: 13px; font-weight: 600; cursor: pointer; font-family: inherit;
 }
-.btn-ghost:hover:not(:disabled) { background: #112040; }
+.btn-ghost:hover:not(:disabled) { background: #f7fafd; }
 .btn-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
 
-.muted { color: #7a9ab8; }
+.muted { color: #6a819a; }
 </style>

--- a/frontend/src/components/ops/OpsIncidentListPage.vue
+++ b/frontend/src/components/ops/OpsIncidentListPage.vue
@@ -93,6 +93,13 @@ function formatRelative(iso: string): string {
 <template>
   <div class="ops-wrap">
 
+    <!-- 페이지 타이틀 -->
+    <div class="ops-card title-card">
+      <p class="monitor-badge">INCIDENT MONITOR</p>
+      <h1 class="page-title">결제 운영 대시보드</h1>
+      <p class="page-desc">결제·예약·좌석 상태 불일치를 탐지하고 AI가 분석한 운영 이상 사건을 확인하세요.</p>
+    </div>
+
     <!-- 필터 바 -->
     <div class="ops-card filter-bar">
       <select v-model="filterSeverity" @change="applyFilters">
@@ -199,43 +206,66 @@ function formatRelative(iso: string): string {
 </template>
 
 <style scoped>
-.ops-wrap { display: flex; flex-direction: column; gap: 16px; }
+.ops-wrap { display: flex; flex-direction: column; gap: 20px; }
 
 .ops-card {
-  background: #0d1e35;
-  border: 1px solid #1e3553;
+  background: #ffffff;
+  border: 1px solid #d8e2ef;
   border-radius: 16px;
 }
 
+/* 타이틀 카드 */
+.title-card { padding: 28px 32px; }
+.monitor-badge {
+  display: inline-flex;
+  align-items: center;
+  background: #f7fafd;
+  border: 1px solid #d6e3f2;
+  border-radius: 999px;
+  padding: 4px 14px;
+  font-size: 12px;
+  font-weight: 700;
+  color: #4f6480;
+  margin-bottom: 10px;
+}
+.page-title { font-size: 26px; font-weight: 800; color: #173451; margin: 0 0 6px; }
+.page-desc  { font-size: 14px; color: #6a819a; margin: 0; }
+
+/* 필터 바 */
 .filter-bar {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   gap: 10px;
-  padding: 14px 20px;
+  padding: 16px 20px;
 }
 
 .filter-bar select,
 .filter-bar input {
-  background: #112040;
-  border: 1px solid #1e3553;
-  color: #e2eaf4;
+  background: #f9fbfe;
+  border: 1px solid #d6e3f2;
+  color: #173451;
   border-radius: 8px;
-  padding: 7px 12px;
+  padding: 8px 12px;
   font-size: 13px;
+  font-family: inherit;
+  outline: none;
 }
+.filter-bar select:focus,
+.filter-bar input:focus { border-color: #ff7a00; }
 
 .refresh-btn {
   margin-left: auto;
-  padding: 7px 16px;
+  padding: 8px 18px;
   font-size: 13px;
 }
 
+/* 에러 */
 .error-banner {
   padding: 14px 20px;
-  color: #fca5a5;
-  background: #450a0a;
-  border-color: #7f1d1d;
+  color: #b91c1c;
+  background: #fef2f2;
+  border-color: #fca5a5;
 }
 
 .table-wrap { overflow: hidden; }
@@ -247,8 +277,8 @@ function formatRelative(iso: string): string {
 }
 
 .incident-table thead tr {
-  background: #112040;
-  color: #7a9ab8;
+  background: #f7fafd;
+  color: #6a819a;
   font-size: 11px;
   text-transform: uppercase;
   letter-spacing: 0.05em;
@@ -256,72 +286,87 @@ function formatRelative(iso: string): string {
 
 .incident-table th,
 .incident-table td {
-  padding: 12px 18px;
+  padding: 13px 20px;
   text-align: left;
-  border-bottom: 1px solid #1e3553;
+  border-bottom: 1px solid #d6e3f2;
 }
 
 .incident-table tbody tr:last-child td { border-bottom: none; }
 
 .incident-row { cursor: pointer; transition: background 0.12s; }
-.incident-row:hover { background: #112040; }
+.incident-row:hover { background: #f7fafd; }
 .incident-row.resolved { opacity: 0.55; }
 
-.center-cell { text-align: center; color: #7a9ab8; padding: 32px; }
+.center-cell { text-align: center; color: #6a819a; padding: 32px; }
 
 .badge {
   display: inline-block;
-  padding: 3px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
   font-size: 11px;
   font-weight: 700;
   white-space: nowrap;
 }
-.badge-critical { background: #7f1d1d; color: #fca5a5; }
-.badge-high     { background: #7c2d12; color: #fdba74; }
-.badge-medium   { background: #713f12; color: #fde68a; }
-.badge-low      { background: #1e3a5f; color: #93c5fd; }
+.badge-critical { background: #fee2e2; color: #b91c1c; border: 1px solid #fca5a5; }
+.badge-high     { background: #ffedd5; color: #c2410c; border: 1px solid #fdba74; }
+.badge-medium   { background: #fef9c3; color: #92400e; border: 1px solid #fde68a; }
+.badge-low      { background: #dbeafe; color: #1d4ed8; border: 1px solid #93c5fd; }
 
 .status-badge {
   display: inline-block;
-  padding: 3px 8px;
+  padding: 3px 10px;
   border-radius: 999px;
   font-size: 11px;
   font-weight: 600;
   white-space: nowrap;
 }
-.status-open         { background: #1e3a5f; color: #93c5fd; }
-.status-analyzing    { background: #312e81; color: #c4b5fd; }
-.status-analyzed     { background: #164e63; color: #67e8f9; }
-.status-acknowledged { background: #374151; color: #d1d5db; }
-.status-resolved     { background: #14532d; color: #86efac; }
+.status-open         { background: #dbeafe; color: #1e40af; border: 1px solid #bfdbfe; }
+.status-analyzing    { background: #ede9fe; color: #6d28d9; border: 1px solid #ddd6fe; }
+.status-analyzed     { background: #cffafe; color: #0e7490; border: 1px solid #a5f3fc; }
+.status-acknowledged { background: #f1f5f9; color: #475569; border: 1px solid #cbd5e1; }
+.status-resolved     { background: #dcfce7; color: #15803d; border: 1px solid #bbf7d0; }
 
-.type-cell   { font-weight: 600; }
-.summary-cell { color: #7a9ab8; max-width: 360px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-.time-cell   { font-size: 12px; white-space: nowrap; }
-.muted       { color: #7a9ab8; }
-.italic      { font-style: italic; }
+.type-cell    { font-weight: 700; color: #173451; }
+.summary-cell { color: #4f6480; max-width: 360px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.time-cell    { font-size: 12px; white-space: nowrap; }
+.muted        { color: #6a819a; }
+.italic       { font-style: italic; }
 
 .pagination {
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 12px 18px;
-  border-top: 1px solid #1e3553;
+  padding: 13px 20px;
+  border-top: 1px solid #d6e3f2;
   font-size: 12px;
 }
 .page-btns { display: flex; align-items: center; gap: 8px; }
-.page-num  { color: #e2eaf4; font-weight: 600; }
+.page-num  { color: #173451; font-weight: 600; }
 
 .btn-ghost {
   background: transparent;
-  border: 1px solid #1e3553;
-  color: #e2eaf4;
+  border: 1px solid #d8e2ef;
+  color: #173451;
   border-radius: 8px;
-  padding: 6px 14px;
-  font-size: 12px;
+  padding: 7px 16px;
+  font-size: 13px;
+  font-weight: 600;
   cursor: pointer;
+  font-family: inherit;
 }
-.btn-ghost:hover:not(:disabled) { background: #112040; }
+.btn-ghost:hover:not(:disabled) { background: #f7fafd; }
 .btn-ghost:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.btn-orange {
+  background: #ff7a00;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 8px 18px;
+  font-size: 13px;
+  font-weight: 700;
+  cursor: pointer;
+  font-family: inherit;
+}
+.btn-orange:hover { background: #e86f00; }
 </style>

--- a/yewon/ops-dashboard-mockup.html
+++ b/yewon/ops-dashboard-mockup.html
@@ -1,0 +1,670 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>결제 운영 대시보드 — FairlineTicket</title>
+  <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@400;500;600;700;800&family=Noto+Sans+KR:wght@400;500;700;900&display=swap" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      --bg-grad: radial-gradient(circle at 8% 0%, #f7fbff 0%, #edf4fc 35%, #f3f7fc 100%);
+      --text:    #173451;
+      --muted:   #4f6480;
+      --muted2:  #6a819a;
+      --orange:  #ff7a00;
+      --orange2: #e86f00;
+      --border:  #d8e2ef;
+      --border2: #d6e3f2;
+      --card:    #ffffff;
+      --util-bg: #f7fafd;
+      --input-bg:#f9fbfe;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      color: var(--text);
+      font-family: 'Manrope', 'Noto Sans KR', sans-serif;
+      background: var(--bg-grad);
+      min-height: 100vh;
+    }
+
+    /* ── 공통 ── */
+    .card {
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 16px;
+    }
+    .card-inner {
+      background: var(--util-bg);
+      border: 1px solid var(--border2);
+      border-radius: 12px;
+    }
+    .btn-orange {
+      background: var(--orange);
+      color: #fff;
+      border-radius: 10px;
+      font-weight: 700;
+      transition: background .15s;
+    }
+    .btn-orange:hover { background: var(--orange2); }
+    .btn-outline {
+      border: 1px solid var(--border);
+      color: var(--text);
+      border-radius: 10px;
+      font-weight: 600;
+      background: transparent;
+    }
+    .btn-outline:hover { background: var(--util-bg); }
+    .btn-outline-disabled {
+      border: 1px solid var(--border2);
+      color: var(--muted2);
+      border-radius: 10px;
+      font-weight: 600;
+      background: transparent;
+      cursor: not-allowed;
+      opacity: .5;
+    }
+
+    /* ── severity badges ── */
+    .badge-critical { background:#fee2e2; color:#b91c1c; border:1px solid #fca5a5; }
+    .badge-high     { background:#ffedd5; color:#c2410c; border:1px solid #fdba74; }
+    .badge-medium   { background:#fef9c3; color:#92400e; border:1px solid #fde68a; }
+    .badge-low      { background:#dbeafe; color:#1d4ed8; border:1px solid #93c5fd; }
+
+    /* ── status badges ── */
+    .status-open         { background:#dbeafe; color:#1e40af; border:1px solid #bfdbfe; }
+    .status-analyzing    { background:#ede9fe; color:#6d28d9; border:1px solid #ddd6fe; }
+    .status-analyzed     { background:#cffafe; color:#0e7490; border:1px solid #a5f3fc; }
+    .status-acknowledged { background:#f1f5f9; color:#475569; border:1px solid #cbd5e1; }
+    .status-resolved     { background:#dcfce7; color:#15803d; border:1px solid #bbf7d0; }
+
+    /* ── table ── */
+    .row-hover:hover { background: var(--util-bg); cursor: pointer; }
+    table { width:100%; border-collapse: collapse; }
+    thead tr { background: var(--util-bg); }
+    tbody tr { border-top: 1px solid var(--border2); }
+
+    /* ── filters ── */
+    select, input[type=text] {
+      background: var(--input-bg);
+      border: 1px solid var(--border2);
+      color: var(--text);
+      border-radius: 8px;
+      padding: 8px 12px;
+      font-size: 13px;
+      font-family: inherit;
+      outline: none;
+    }
+    select:focus, input[type=text]:focus { border-color: var(--orange); }
+
+    /* ── nav tab ── */
+    .tab-active   { border-bottom: 2px solid var(--orange); color: var(--orange); font-weight: 700; }
+    .tab-inactive { border-bottom: 2px solid transparent; color: var(--muted); font-weight: 600; }
+
+    /* ── view toggle ── */
+    #view-list   { display: block; }
+    #view-detail { display: none; }
+    body.detail #view-list   { display: none; }
+    body.detail #view-detail { display: block; }
+
+    /* ── tab pane ── */
+    .tab-pane         { display: none; }
+    .tab-pane.active  { display: block; }
+
+    /* ── timeline ── */
+    .dot  { width:10px; height:10px; border-radius:50%; flex-shrink:0; margin-top:5px; }
+    .vline{ width:2px; background:var(--border); flex-shrink:0; margin:0 4px; }
+
+    /* ── confidence bar ── */
+    .conf-track { background: var(--border2); border-radius:4px; height:7px; overflow:hidden; }
+    .conf-fill  { height:100%; background: var(--orange); border-radius:4px; }
+
+    /* ── signal chip ── */
+    .chip {
+      display:inline-flex; align-items:center;
+      background: var(--util-bg); border:1px solid var(--border2);
+      border-radius:8px; padding:4px 10px;
+      font-size:12px; color:var(--muted); font-weight:600;
+    }
+
+    ::-webkit-scrollbar { width:5px; height:5px; }
+    ::-webkit-scrollbar-track { background: transparent; }
+    ::-webkit-scrollbar-thumb { background: var(--border); border-radius:3px; }
+  </style>
+</head>
+<body>
+
+<!-- ══════════════ HEADER (기존 Header.vue 동일 구조) ══════════════ -->
+<header style="position:sticky;top:0;z-index:50;background:rgba(255,255,255,.95);backdrop-filter:blur(6px);border-bottom:1px solid var(--border);">
+  <!-- utility bar -->
+  <div style="background:var(--util-bg);border-bottom:1px solid var(--border2);padding:7px 0;">
+    <div style="max-width:1280px;margin:0 auto;display:flex;justify-content:flex-end;gap:16px;padding:0 24px;font-size:12px;color:var(--muted);">
+      <button style="color:var(--muted);background:none;border:none;cursor:pointer;font-family:inherit;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">로그아웃</button>
+      <span style="color:var(--border);">|</span>
+      <button style="color:var(--muted);background:none;border:none;cursor:pointer;font-family:inherit;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">고객센터</button>
+      <span style="color:var(--border);">|</span>
+      <button style="color:var(--muted);background:none;border:none;cursor:pointer;font-family:inherit;" onmouseover="this.style.textDecoration='underline'" onmouseout="this.style.textDecoration='none'">마이페이지</button>
+      <span style="color:var(--border);">|</span>
+      <button style="color:var(--orange);font-weight:700;background:none;border:none;cursor:pointer;font-family:inherit;">운영 대시보드</button>
+    </div>
+  </div>
+  <!-- logo row -->
+  <div style="max-width:1280px;margin:0 auto;display:flex;align-items:center;justify-content:space-between;padding:12px 24px;">
+    <div style="display:flex;align-items:center;gap:32px;">
+      <img src="https://raw.githubusercontent.com/SKALA-Mini-Project-1/SKALA-Mini-Project-2/refs/heads/dev/frontend/public/fairline_ticket_favicon.jpg"
+           alt="FairlineTicket" style="height:48px;width:auto;object-fit:contain;border-radius:8px;" onerror="this.style.display='none'" />
+      <span style="font-size:20px;font-weight:800;color:var(--orange);letter-spacing:-.5px;">FairlineTicket</span>
+    </div>
+    <span style="font-size:13px;font-weight:600;color:var(--muted);">결제 운영 대시보드</span>
+  </div>
+  <!-- nav -->
+  <div style="border-top:1px solid var(--border2);">
+    <div style="max-width:1280px;margin:0 auto;padding:0 24px;display:flex;gap:2px;">
+      <button style="border:none;border-bottom:2px solid transparent;background:none;padding:10px 20px;font-size:13px;font-weight:700;color:var(--muted2);font-family:inherit;cursor:pointer;">메인</button>
+      <button style="border:none;border-bottom:2px solid transparent;background:none;padding:10px 20px;font-size:13px;font-weight:700;color:var(--muted2);font-family:inherit;cursor:pointer;">콘서트</button>
+      <button style="border:none;border-bottom:2px solid var(--orange);background:none;padding:10px 20px;font-size:13px;font-weight:700;color:var(--orange);font-family:inherit;cursor:pointer;">운영 대시보드</button>
+    </div>
+  </div>
+</header>
+
+<!-- ══════════════ VIEW: LIST ══════════════ -->
+<div id="view-list">
+<main style="max-width:1280px;margin:0 auto;padding:32px 24px;display:flex;flex-direction:column;gap:20px;">
+
+  <!-- 페이지 타이틀 -->
+  <div style="background:var(--card);border:1px solid var(--border);border-radius:16px;padding:28px 32px;">
+    <p style="display:inline-flex;align-items:center;background:var(--util-bg);border:1px solid var(--border2);border-radius:999px;padding:4px 14px;font-size:12px;font-weight:700;color:var(--muted);margin-bottom:10px;">INCIDENT MONITOR</p>
+    <h1 style="font-size:28px;font-weight:800;color:var(--text);margin:0 0 6px;">결제 운영 대시보드</h1>
+    <p style="font-size:14px;color:var(--muted2);margin:0;">결제·예약·좌석 상태 불일치를 탐지하고 AI가 분석한 운영 이상 사건을 확인하세요.</p>
+  </div>
+
+  <!-- 필터 바 -->
+  <div class="card" style="padding:16px 20px;display:flex;flex-wrap:wrap;align-items:center;gap:10px;">
+    <select>
+      <option value="">심각도 전체</option>
+      <option>CRITICAL</option>
+      <option>HIGH</option>
+      <option>MEDIUM</option>
+      <option>LOW</option>
+    </select>
+    <select>
+      <option value="">상태 전체</option>
+      <option>OPEN</option>
+      <option>ANALYZING</option>
+      <option>ANALYZED</option>
+      <option>ACKNOWLEDGED</option>
+      <option>RESOLVED</option>
+    </select>
+    <select>
+      <option value="">유형 전체</option>
+      <option>중복 결제</option>
+      <option>유령 주문</option>
+      <option>좀비 예약</option>
+      <option>미확정 결제</option>
+    </select>
+    <input type="text" placeholder="Incident ID 검색…" style="flex:1;min-width:180px;" />
+    <button class="btn-orange" style="padding:8px 18px;font-size:13px;">새로고침</button>
+  </div>
+
+  <!-- 테이블 -->
+  <div class="card" style="overflow:hidden;">
+    <table>
+      <thead>
+        <tr>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">심각도</th>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">유형</th>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">상태</th>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">AI 요약</th>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">AI 분석</th>
+          <th style="padding:12px 20px;text-align:left;font-size:11px;font-weight:700;color:var(--muted2);letter-spacing:.06em;text-transform:uppercase;">갱신 시각</th>
+        </tr>
+      </thead>
+      <tbody>
+
+        <!-- Row 1 -->
+        <tr class="row-hover" onclick="showDetail()">
+          <td style="padding:14px 20px;"><span class="badge-critical" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🔴 CRITICAL</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">중복 결제</td>
+          <td style="padding:14px 20px;"><span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">ANALYZED</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted);max-width:300px;">동일 bookingId에 결제 확정이 2건 반영되어 이중 청구 가능성이 높습니다.</td>
+          <td style="padding:14px 20px;"><span style="font-size:11px;font-weight:600;color:var(--muted);">v2 · 0.89</span></td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">3분 전</td>
+        </tr>
+
+        <!-- Row 2 -->
+        <tr class="row-hover">
+          <td style="padding:14px 20px;"><span class="badge-high" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🟠 HIGH</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">유령 주문</td>
+          <td style="padding:14px 20px;"><span class="status-analyzing" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">ANALYZING</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted2);font-style:italic;">AI 분석 진행 중…</td>
+          <td style="padding:14px 20px;font-size:11px;color:var(--muted2);">대기 중</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">11분 전</td>
+        </tr>
+
+        <!-- Row 3 -->
+        <tr class="row-hover">
+          <td style="padding:14px 20px;"><span class="badge-high" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🟠 HIGH</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">미확정 결제</td>
+          <td style="padding:14px 20px;"><span class="status-open" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">OPEN</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted2);font-style:italic;">AI 분석 대기 중</td>
+          <td style="padding:14px 20px;font-size:11px;color:var(--muted2);">대기 중</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">15분 전</td>
+        </tr>
+
+        <!-- Row 4 -->
+        <tr class="row-hover">
+          <td style="padding:14px 20px;"><span class="badge-critical" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🔴 CRITICAL</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">중복 결제</td>
+          <td style="padding:14px 20px;"><span class="status-open" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">OPEN</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted2);font-style:italic;">AI 분석 대기 중</td>
+          <td style="padding:14px 20px;font-size:11px;color:var(--muted2);">대기 중</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">18분 전</td>
+        </tr>
+
+        <!-- Row 5 -->
+        <tr class="row-hover">
+          <td style="padding:14px 20px;"><span class="badge-medium" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🟡 MEDIUM</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">좀비 예약</td>
+          <td style="padding:14px 20px;"><span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">ANALYZED</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted);max-width:300px;">hold TTL 만료 후 seat lock이 잔존하고 있어 좌석 점유 해제 누락이 의심됩니다.</td>
+          <td style="padding:14px 20px;font-size:11px;font-weight:600;color:var(--muted);">v1 · 0.78</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">22분 전</td>
+        </tr>
+
+        <!-- Row 6 -->
+        <tr class="row-hover">
+          <td style="padding:14px 20px;"><span class="badge-high" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🟠 HIGH</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">유령 주문</td>
+          <td style="padding:14px 20px;"><span class="status-acknowledged" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">ACKNOWLEDGED</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted);max-width:300px;">결제 성공 후 booking.confirmed 이벤트 누락으로 ticketing 후처리 미완료 의심.</td>
+          <td style="padding:14px 20px;font-size:11px;font-weight:600;color:var(--muted);">v2 · 0.84</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">1시간 전</td>
+        </tr>
+
+        <!-- Row 7 -->
+        <tr style="opacity:.55;">
+          <td style="padding:14px 20px;"><span class="badge-critical" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">🔴 CRITICAL</span></td>
+          <td style="padding:14px 20px;font-weight:700;font-size:14px;color:var(--text);">중복 결제</td>
+          <td style="padding:14px 20px;"><span class="status-resolved" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">✅ RESOLVED</span></td>
+          <td style="padding:14px 20px;font-size:13px;color:var(--muted);">수동 환불 처리 완료. 중복 청구된 1건 환불 조치됨.</td>
+          <td style="padding:14px 20px;font-size:11px;font-weight:600;color:var(--muted);">v1 · 0.91</td>
+          <td style="padding:14px 20px;font-size:12px;color:var(--muted2);">3시간 전</td>
+        </tr>
+
+      </tbody>
+    </table>
+
+    <!-- 페이지네이션 -->
+    <div style="padding:14px 20px;border-top:1px solid var(--border2);display:flex;align-items:center;justify-content:space-between;">
+      <span style="font-size:12px;color:var(--muted2);">총 7건</span>
+      <div style="display:flex;gap:6px;">
+        <button class="btn-outline" style="padding:6px 14px;font-size:12px;opacity:.4;">← 이전</button>
+        <button class="btn-orange" style="padding:6px 14px;font-size:12px;">1</button>
+        <button class="btn-outline" style="padding:6px 14px;font-size:12px;opacity:.4;">다음 →</button>
+      </div>
+    </div>
+  </div>
+
+</main>
+</div><!-- /view-list -->
+
+
+<!-- ══════════════ VIEW: DETAIL ══════════════ -->
+<div id="view-detail">
+<main style="max-width:1280px;margin:0 auto;padding:32px 24px;display:flex;flex-direction:column;gap:20px;">
+
+  <!-- 브레드크럼 -->
+  <button onclick="showList()" style="background:none;border:none;cursor:pointer;font-family:inherit;font-size:13px;font-weight:600;color:var(--muted);display:inline-flex;align-items:center;gap:6px;padding:0;">
+    ← 목록으로
+  </button>
+
+  <!-- 헤더 카드 -->
+  <div class="card" style="padding:28px 32px;">
+    <div style="display:flex;flex-wrap:wrap;align-items:flex-start;justify-content:space-between;gap:16px;">
+      <div style="display:flex;flex-direction:column;gap:10px;">
+        <div style="display:flex;flex-wrap:wrap;align-items:center;gap:10px;">
+          <span class="badge-critical" style="font-size:12px;font-weight:700;padding:4px 14px;border-radius:999px;">🔴 CRITICAL</span>
+          <span style="font-size:20px;font-weight:800;color:var(--text);">중복 결제 (DUPLICATE_PAYMENT)</span>
+          <span class="status-analyzed" style="font-size:12px;font-weight:700;padding:4px 14px;border-radius:999px;">ANALYZED</span>
+        </div>
+        <div style="display:flex;flex-wrap:wrap;gap:20px;font-size:12px;color:var(--muted2);">
+          <span>📌 Incident ID: <span style="font-family:monospace;color:var(--text);font-weight:600;">inc_001</span></span>
+          <span>🕐 최초 감지: <span style="color:var(--text);font-weight:600;">2026-04-30 10:32:05</span></span>
+          <span>🔄 최종 갱신: <span style="color:var(--text);font-weight:600;">2026-04-30 10:35:22</span></span>
+        </div>
+      </div>
+      <div style="display:flex;flex-wrap:wrap;gap:8px;">
+        <button class="btn-orange" style="padding:10px 18px;font-size:13px;">✅ 확인 완료 (ACKNOWLEDGE)</button>
+        <button class="btn-outline-disabled" style="padding:10px 18px;font-size:13px;">🔧 해결됨 (RESOLVE)</button>
+        <button class="btn-outline" style="padding:10px 18px;font-size:13px;">🔄 재분석 요청</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- 2컬럼 -->
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:20px;">
+
+    <!-- 좌: AI 분석 결과 -->
+    <div class="card" style="padding:24px;display:flex;flex-direction:column;gap:18px;">
+      <div style="display:flex;justify-content:space-between;align-items:center;">
+        <h2 style="margin:0;font-size:15px;font-weight:800;color:var(--text);">🤖 AI 분석 결과</h2>
+        <span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">v2 · 성공</span>
+      </div>
+
+      <!-- 신뢰도 -->
+      <div style="display:flex;flex-direction:column;gap:6px;">
+        <div style="display:flex;justify-content:space-between;font-size:12px;color:var(--muted2);">
+          <span>신뢰도 (Confidence)</span>
+          <span style="font-weight:700;color:var(--orange);">0.89</span>
+        </div>
+        <div class="conf-track"><div class="conf-fill" style="width:89%;"></div></div>
+      </div>
+
+      <!-- 요약 -->
+      <div class="card-inner" style="padding:14px 16px;">
+        <p style="margin:0 0 4px;font-size:11px;font-weight:700;color:var(--muted2);">요약 (Summary)</p>
+        <p style="margin:0;font-size:13px;line-height:1.6;color:var(--text);">동일 bookingId에 결제 확정이 2건 반영되어 이중 청구 가능성이 높습니다. 즉각적인 운영자 확인과 환불 검토가 필요합니다.</p>
+      </div>
+
+      <!-- 추정 원인 -->
+      <div style="display:flex;flex-direction:column;gap:6px;">
+        <p style="margin:0;font-size:11px;font-weight:700;color:var(--muted2);">추정 원인 (Suspected Root Cause)</p>
+        <p style="margin:0;font-size:13px;line-height:1.6;color:var(--muted);">동일 bookingId(book_a1b2c3)에 연결된 pay_aaa111, pay_bbb222 두 건이 모두 CONFIRMED 상태입니다. 네트워크 재시도 중 멱등성 키가 누락되어 동일 결제가 중복 승인되었을 가능성이 높습니다.</p>
+      </div>
+
+      <!-- 권장 액션 -->
+      <div style="display:flex;flex-direction:column;gap:8px;">
+        <p style="margin:0;font-size:11px;font-weight:700;color:var(--muted2);">권장 액션 (Recommended Actions)</p>
+        <ol style="margin:0;padding:0;list-style:none;display:flex;flex-direction:column;gap:8px;">
+          <li style="display:flex;gap:10px;align-items:flex-start;font-size:13px;">
+            <span class="btn-orange" style="min-width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:11px;border-radius:999px;flex-shrink:0;">1</span>
+            <span><strong>두 결제 상태 재조회</strong> — pay_aaa111, pay_bbb222 모두 CONFIRMED인지 확인</span>
+          </li>
+          <li style="display:flex;gap:10px;align-items:flex-start;font-size:13px;">
+            <span class="btn-orange" style="min-width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:11px;border-radius:999px;flex-shrink:0;">2</span>
+            <span><strong>PG 승인 내역 대조</strong> — PG사 측 승인 건수와 내부 반영 건수 비교</span>
+          </li>
+          <li style="display:flex;gap:10px;align-items:flex-start;font-size:13px;">
+            <span class="btn-orange" style="min-width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:11px;border-radius:999px;flex-shrink:0;">3</span>
+            <span><strong>환불 대상 결제 특정</strong> — 나중에 생성된 pay_bbb222를 환불 후보로 등록</span>
+          </li>
+          <li style="display:flex;gap:10px;align-items:flex-start;font-size:13px;">
+            <span class="btn-orange" style="min-width:22px;height:22px;display:flex;align-items:center;justify-content:center;font-size:11px;border-radius:999px;flex-shrink:0;">4</span>
+            <span><strong>멱등성 키 처리 로그 확인</strong> — 재시도 구간 idempotency 누락 여부 점검</span>
+          </li>
+        </ol>
+      </div>
+
+      <!-- 인간 승인 필요 -->
+      <div style="background:#fff7ed;border:1px solid #fdba74;border-radius:12px;padding:14px 16px;display:flex;gap:12px;align-items:flex-start;">
+        <span style="font-size:18px;">⚠️</span>
+        <div>
+          <p style="margin:0 0 3px;font-size:13px;font-weight:700;color:#c2410c;">운영자 승인 필요 (needsHumanApproval: true)</p>
+          <p style="margin:0;font-size:12px;color:#9a3412;">자동 조치 비권장. 환불 또는 상태 변경은 운영자 검증 후 수행하세요.</p>
+        </div>
+      </div>
+    </div>
+
+    <!-- 우: 스냅샷 + 리소스 + 분석 상태 -->
+    <div style="display:flex;flex-direction:column;gap:16px;">
+
+      <!-- 현재 상태 스냅샷 -->
+      <div class="card" style="padding:24px;">
+        <h2 style="margin:0 0 14px;font-size:15px;font-weight:800;color:var(--text);">📋 현재 상태 스냅샷</h2>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:10px;">
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">paymentStatus (1)</p>
+            <span style="font-family:monospace;font-weight:700;color:#15803d;">CONFIRMED</span>
+          </div>
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">paymentStatus (2)</p>
+            <span style="font-family:monospace;font-weight:700;color:#b91c1c;">CONFIRMED ⚠</span>
+          </div>
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">bookingStatus</p>
+            <span style="font-family:monospace;font-weight:700;color:#15803d;">CONFIRMED</span>
+          </div>
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">seatReservedStatus</p>
+            <span style="font-family:monospace;font-weight:700;color:#15803d;">RESERVED</span>
+          </div>
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">webhookReceived</p>
+            <span style="font-family:monospace;font-weight:700;color:#15803d;">✓ DONE</span>
+          </div>
+          <div class="card-inner" style="padding:10px 14px;">
+            <p style="margin:0 0 4px;font-size:11px;color:var(--muted2);font-weight:600;">pgApproved</p>
+            <span style="font-family:monospace;font-weight:700;color:#b91c1c;">✓ 2건 ⚠</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 관련 리소스 -->
+      <div class="card" style="padding:24px;">
+        <h2 style="margin:0 0 14px;font-size:15px;font-weight:800;color:var(--text);">🔗 관련 리소스</h2>
+        <div style="display:flex;flex-direction:column;gap:8px;font-size:13px;">
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">paymentId (1)</span><span style="font-family:monospace;font-weight:600;">pay_aaa111</span></div>
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">paymentId (2)</span><span style="font-family:monospace;font-weight:600;color:#b91c1c;">pay_bbb222 ⚠</span></div>
+          <div style="display:flex;justify-content:space-between;border-top:1px solid var(--border2);padding-top:8px;"><span style="color:var(--muted2);">bookingId</span><span style="font-family:monospace;font-weight:600;">book_a1b2c3</span></div>
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">userId</span><span style="font-family:monospace;font-weight:600;">17</span></div>
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">concertId</span><span style="font-family:monospace;font-weight:600;">1</span></div>
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">scheduleId</span><span style="font-family:monospace;font-weight:600;">3</span></div>
+          <div style="display:flex;justify-content:space-between;"><span style="color:var(--muted2);">seatIds</span><span style="font-family:monospace;font-weight:600;">[101, 102]</span></div>
+        </div>
+      </div>
+
+      <!-- 최신 분석 상태 -->
+      <div class="card" style="padding:24px;">
+        <h2 style="margin:0 0 12px;font-size:15px;font-weight:800;color:var(--text);">🧠 최신 분석 상태</h2>
+        <div style="display:flex;align-items:center;gap:10px;margin-bottom:6px;">
+          <span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">v2 · COMPLETED</span>
+          <span style="font-size:12px;color:var(--muted2);">2026-04-30 10:35:22</span>
+        </div>
+        <p style="margin:0;font-size:12px;color:var(--muted2);">claude-sonnet-4-6 &nbsp;·&nbsp; trigger: UPDATE_DETECTED &nbsp;·&nbsp; 재시도 0회</p>
+      </div>
+
+    </div>
+  </div><!-- /2col -->
+
+  <!-- Detector 신호 -->
+  <div class="card" style="padding:24px;">
+    <h2 style="margin:0 0 12px;font-size:15px;font-weight:800;color:var(--text);">📡 Detector 신호</h2>
+    <div style="display:flex;flex-wrap:wrap;gap:8px;">
+      <span class="chip">⚡ DUPLICATE_PAYMENT_CONFIRMED</span>
+      <span class="chip">⚡ MULTIPLE_PAYMENTS_FOR_BOOKING</span>
+    </div>
+  </div>
+
+  <!-- 타임라인 -->
+  <div class="card" style="padding:24px;">
+    <h2 style="margin:0 0 16px;font-size:15px;font-weight:800;color:var(--text);">📅 이벤트 타임라인</h2>
+    <div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#22c55e;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:20:01</span>
+          <span style="margin-left:10px;font-weight:700;color:var(--text);">booking.created</span>
+          <span style="margin-left:8px;font-size:11px;background:var(--util-bg);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">ticketing</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#22c55e;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:20:15</span>
+          <span style="margin-left:10px;font-weight:700;color:var(--text);">payment.submitted (pay_aaa111)</span>
+          <span style="margin-left:8px;font-size:11px;background:var(--util-bg);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">payment</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#22c55e;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:20:44</span>
+          <span style="margin-left:10px;font-weight:700;color:var(--text);">pg.webhook.received:DONE (pay_aaa111)</span>
+          <span style="margin-left:8px;font-size:11px;background:var(--util-bg);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">payment</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#22c55e;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:20:45</span>
+          <span style="margin-left:10px;font-weight:700;color:var(--text);">payment.confirmed (pay_aaa111)</span>
+          <span style="margin-left:8px;font-size:11px;background:var(--util-bg);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">payment</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#f97316;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:21:02</span>
+          <span style="margin-left:10px;font-weight:700;color:#c2410c;">payment.submitted (pay_bbb222) — 재시도 요청</span>
+          <span style="margin-left:8px;font-size:11px;background:#fff7ed;border:1px solid #fdba74;border-radius:6px;padding:2px 8px;color:#c2410c;font-weight:600;">⚠ 중복 의심</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#ef4444;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:21:38</span>
+          <span style="margin-left:10px;font-weight:700;color:#b91c1c;">pg.webhook.received:DONE (pay_bbb222)</span>
+          <span style="margin-left:8px;font-size:11px;background:#fee2e2;border:1px solid #fca5a5;border-radius:6px;padding:2px 8px;color:#b91c1c;font-weight:600;">🔴 중복 PG 승인</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:#ef4444;"></div>
+          <div class="vline" style="height:32px;"></div>
+        </div>
+        <div style="padding-bottom:16px;font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:21:39</span>
+          <span style="margin-left:10px;font-weight:700;color:#b91c1c;">payment.confirmed (pay_bbb222) — 중복 확정</span>
+          <span style="margin-left:8px;font-size:11px;background:#fee2e2;border:1px solid #fca5a5;border-radius:6px;padding:2px 8px;color:#b91c1c;font-weight:600;">🔴 이상 감지</span>
+        </div>
+      </div>
+
+      <div style="display:flex;gap:12px;">
+        <div style="display:flex;flex-direction:column;align-items:center;">
+          <div class="dot" style="background:var(--orange);"></div>
+        </div>
+        <div style="font-size:13px;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);">10:21:39</span>
+          <span style="margin-left:10px;font-weight:700;color:var(--orange);">⚡ incident 생성 — DUPLICATE_PAYMENT_CONFIRMED 신호 발화</span>
+        </div>
+      </div>
+
+    </div>
+  </div>
+
+  <!-- 하단 탭 -->
+  <div class="card" style="overflow:hidden;">
+    <div style="display:flex;border-bottom:1px solid var(--border2);">
+      <button id="tab-analysis-btn" class="tab-active" onclick="switchTab('analysis')" style="background:none;border:none;padding:14px 24px;font-size:13px;cursor:pointer;font-family:inherit;">📊 분석 이력</button>
+      <button id="tab-ops-btn" class="tab-inactive" onclick="switchTab('ops')" style="background:none;border:none;padding:14px 24px;font-size:13px;cursor:pointer;font-family:inherit;">🧑‍💼 운영자 처리 이력</button>
+    </div>
+
+    <!-- 분석 이력 -->
+    <div id="tab-analysis" class="tab-pane active" style="padding:20px;display:flex;flex-direction:column;gap:10px;">
+      <div class="card-inner" style="padding:16px;display:flex;justify-content:space-between;gap:16px;align-items:flex-start;">
+        <div style="display:flex;flex-direction:column;gap:6px;">
+          <div style="display:flex;align-items:center;gap:8px;">
+            <span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">v2 · COMPLETED</span>
+            <span style="font-size:12px;color:var(--muted2);">2026-04-30 10:35:22</span>
+            <span style="font-size:11px;background:var(--card);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">trigger: UPDATE_DETECTED</span>
+          </div>
+          <p style="margin:0;font-size:13px;color:var(--text);">동일 bookingId에 결제 확정이 2건 반영되어 이중 청구 가능성이 높습니다.</p>
+          <p style="margin:0;font-size:12px;color:var(--muted2);">claude-sonnet-4-6 &nbsp;·&nbsp; confidence 0.89 &nbsp;·&nbsp; 재시도 0회</p>
+        </div>
+        <span class="badge-low" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;flex-shrink:0;">최신</span>
+      </div>
+      <div class="card-inner" style="padding:16px;opacity:.65;display:flex;flex-direction:column;gap:6px;">
+        <div style="display:flex;align-items:center;gap:8px;">
+          <span class="status-analyzed" style="font-size:11px;font-weight:700;padding:3px 10px;border-radius:999px;">v1 · COMPLETED</span>
+          <span style="font-size:12px;color:var(--muted2);">2026-04-30 10:33:01</span>
+          <span style="font-size:11px;background:var(--card);border:1px solid var(--border2);border-radius:6px;padding:2px 8px;color:var(--muted2);">trigger: NEW_INCIDENT</span>
+        </div>
+        <p style="margin:0;font-size:13px;color:var(--text);">booking에 연결된 결제가 2건 감지되어 중복 결제 가능성을 확인해야 합니다.</p>
+        <p style="margin:0;font-size:12px;color:var(--muted2);">claude-sonnet-4-6 &nbsp;·&nbsp; confidence 0.82 &nbsp;·&nbsp; 재시도 0회</p>
+      </div>
+    </div>
+
+    <!-- 운영자 처리 이력 -->
+    <div id="tab-ops" class="tab-pane" style="padding:20px;">
+      <div style="display:flex;flex-direction:column;gap:10px;font-size:13px;">
+        <div style="display:flex;gap:14px;align-items:flex-start;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);padding-top:4px;flex-shrink:0;">10:35:22</span>
+          <div class="card-inner" style="padding:12px 16px;flex:1;">
+            <span style="font-weight:700;color:var(--text);">시스템 (incident-agent)</span>
+            <span style="margin:0 8px;color:var(--muted2);">→</span>
+            <span class="status-analyzed" style="font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;">ANALYZED</span>
+            <p style="margin:4px 0 0;font-size:12px;color:var(--muted2);">분석 v2 완료. 자동 상태 전이.</p>
+          </div>
+        </div>
+        <div style="display:flex;gap:14px;align-items:flex-start;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);padding-top:4px;flex-shrink:0;">10:33:01</span>
+          <div class="card-inner" style="padding:12px 16px;flex:1;">
+            <span style="font-weight:700;color:var(--text);">시스템 (incident-agent)</span>
+            <span style="margin:0 8px;color:var(--muted2);">→</span>
+            <span class="status-analyzing" style="font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;">ANALYZED</span>
+            <p style="margin:4px 0 0;font-size:12px;color:var(--muted2);">분석 v1 완료. 자동 상태 전이.</p>
+          </div>
+        </div>
+        <div style="display:flex;gap:14px;align-items:flex-start;">
+          <span style="font-family:monospace;font-size:11px;color:var(--muted2);padding-top:4px;flex-shrink:0;">10:21:39</span>
+          <div class="card-inner" style="padding:12px 16px;flex:1;">
+            <span style="font-weight:700;color:var(--text);">시스템 (incident-detector)</span>
+            <span style="margin:0 8px;color:var(--muted2);">→</span>
+            <span class="status-open" style="font-size:11px;font-weight:700;padding:2px 8px;border-radius:999px;">OPEN</span>
+            <p style="margin:4px 0 0;font-size:12px;color:var(--muted2);">신규 incident 생성. DUPLICATE_PAYMENT_CONFIRMED 신호.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- /탭 -->
+
+</main>
+</div><!-- /view-detail -->
+
+<script>
+  function showDetail() {
+    document.body.classList.add('detail');
+    window.scrollTo(0,0);
+  }
+  function showList() {
+    document.body.classList.remove('detail');
+    window.scrollTo(0,0);
+  }
+  function switchTab(name) {
+    document.querySelectorAll('.tab-pane').forEach(el => el.classList.remove('active'));
+    document.getElementById('tab-' + name).classList.add('active');
+    document.getElementById('tab-analysis-btn').className = 'tab-' + (name==='analysis' ? 'active' : 'inactive');
+    document.getElementById('tab-analysis-btn').style.cssText = 'background:none;border:none;padding:14px 24px;font-size:13px;cursor:pointer;font-family:inherit;';
+    document.getElementById('tab-ops-btn').className = 'tab-' + (name==='ops' ? 'active' : 'inactive');
+    document.getElementById('tab-ops-btn').style.cssText = 'background:none;border:none;padding:14px 24px;font-size:13px;cursor:pointer;font-family:inherit;';
+  }
+</script>
+</body>
+</html>


### PR DESCRIPTION
feat: 결제 운영 대시보드 UI 라이트 테마 전환

## Summary
- 운영자 대시보드(`/ops`) 전체 테마를 다크 → FairlineTicket 라이트 디자인 시스템으로 전환
- 인시던트 목록 페이지에 타이틀 카드(INCIDENT MONITOR 배지, 설명 문구) 추가
- 심각도·상태·유형 배지를 파스텔 컬러 체계로 통일
  (critical/high/medium/low, open/analyzing/analyzed/acknowledged/resolved)
- 운영 화면 설계 검토용 HTML 목업 파일(`yewon/ops-dashboard-mockup.html`) 추가
- 개발 서버 구성 파일(`.claude/launch.json`) 추가

## Changes
| 파일 | 변경 내용 |
|------|-----------|
| `frontend/src/App.vue` | `/ops` 경로 배경·헤더·네비 라이트 테마 전환 |
| `frontend/src/components/ops/OpsIncidentListPage.vue` | 타이틀 카드 추가, 전체 CSS 라이트 테마 |
| `frontend/src/components/ops/OpsIncidentDetailPage.vue` | 전체 CSS 라이트 테마 (카드·배지·타임라인·승인배너) |
| `yewon/ops-dashboard-mockup.html` | 설계 검토용 목업 (mock 데이터 포함) |
| `.claude/launch.json` | 개발 서버 실행 설정 |

## Design Tokens Applied
- Background: radial-gradient(#f7fbff → #edf4fc)
- Primary: #ff7a00 (오렌지)
- Text: #173451 (네이비)
- Card: #ffffff, border #d8e2ef
- Muted: #6a819a
- Font: Manrope, Noto Sans KR

## Notes
- 비즈니스 로직·API 연동 코드는 변경 없음 (스타일만 수정)
- 백엔드 연결 시 기존 incidents.ts 서비스 그대로 동작