### PR TITLE
feat: LLM 신뢰도 기준·타임라인·운영자 리소스 추적·대시보드 UI 개선

### DIFF
--- a/frontend/src/components/ops/OpsIncidentDetailPage.vue
+++ b/frontend/src/components/ops/OpsIncidentDetailPage.vue
@@ -94,7 +94,7 @@ function fmt(iso: string | null | undefined): string {
   })
 }
 
-function parseCurrentState(json: string | null): Record<string, string> {
+function parseCurrentState(json: string | null): Record<string, unknown> {
   if (!json) return {}
   try { return JSON.parse(json) } catch { return {} }
 }
@@ -109,10 +109,51 @@ function parseNestedJson(value: string | null | undefined): Record<string, unkno
   }
 }
 
+function isIsoDate(str: string): boolean {
+  return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(str)
+}
+
+function toDisplayString(val: unknown): string | null {
+  if (val === null || val === undefined || val === '') return null
+  if (typeof val === 'string') return isIsoDate(val) ? fmt(val) : val
+  if (typeof val === 'number') return String(val)
+  return null
+}
+
 const stateSnapshot = computed(() => parseCurrentState(incident.value?.currentState ?? null))
+
 const nestedExtraJson = computed(() => {
   const extraJson = stateSnapshot.value.extraJson
   return typeof extraJson === 'string' ? parseNestedJson(extraJson) : {}
+})
+
+// extraJson을 펼치고, timeline·extraJson 키 자체를 제거한 평탄화 스냅샷
+const flatSnapshot = computed((): Array<{ key: string; val: string }> => {
+  const result: Array<{ key: string; val: string }> = []
+  const skipKeys = new Set(['extraJson', 'timeline'])
+
+  for (const [key, val] of Object.entries(stateSnapshot.value)) {
+    if (skipKeys.has(key)) continue
+    const display = toDisplayString(val)
+    if (display !== null) result.push({ key, val: display })
+  }
+
+  // extraJson 내부 필드를 펼쳐서 추가 (paymentId·bookingId는 관련 리소스에 이미 있으므로 중복 제거)
+  const resourceKeys = new Set(['paymentId', 'bookingId', 'userId', 'concertId', 'scheduleId'])
+  for (const [key, val] of Object.entries(nestedExtraJson.value)) {
+    if (resourceKeys.has(key)) continue
+    const display = toDisplayString(val)
+    if (display !== null) result.push({ key, val: display })
+  }
+
+  return result
+})
+
+// timeline 배열 따로 추출
+const snapshotTimeline = computed((): Array<Record<string, string>> => {
+  const timeline = stateSnapshot.value.timeline
+  if (!Array.isArray(timeline)) return []
+  return timeline as Array<Record<string, string>>
 })
 
 function asDisplayValue(value: unknown): string | number | null {
@@ -318,16 +359,37 @@ function confidencePct(v: AnalysisVersion | null): number {
           <!-- 상태 스냅샷 -->
           <div class="ops-card snapshot-card">
             <p class="section-title">📋 현재 상태 스냅샷</p>
-            <div v-if="incident.currentState" class="snapshot-grid">
-              <div
-                v-for="(val, key) in stateSnapshot"
-                :key="key"
-                class="snapshot-item"
-              >
-                <p class="snapshot-key muted">{{ key }}</p>
-                <p class="snapshot-val">{{ val }}</p>
+            <template v-if="incident.currentState">
+              <div class="snapshot-grid">
+                <div
+                  v-for="item in flatSnapshot"
+                  :key="item.key"
+                  class="snapshot-item"
+                >
+                  <p class="snapshot-key muted">{{ item.key }}</p>
+                  <p class="snapshot-val">{{ item.val }}</p>
+                </div>
               </div>
-            </div>
+              <!-- 이벤트 타임라인 (있는 경우) -->
+              <template v-if="snapshotTimeline.length">
+                <p class="block-label" style="margin-top:14px;">이벤트 흐름</p>
+                <div class="timeline-list">
+                  <div
+                    v-for="(ev, i) in snapshotTimeline"
+                    :key="i"
+                    class="timeline-event"
+                  >
+                    <span class="timeline-dot" />
+                    <div class="timeline-body">
+                      <span class="timeline-type">{{ ev.eventType }}</span>
+                      <span class="muted timeline-source">{{ ev.source }}</span>
+                      <span v-if="ev.note" class="muted timeline-note">— {{ ev.note }}</span>
+                      <span class="muted timeline-time">{{ isIsoDate(ev.occurredAt) ? fmt(ev.occurredAt) : ev.occurredAt }}</span>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </template>
             <p v-else class="muted" style="font-size:13px;">스냅샷 없음</p>
           </div>
 
@@ -537,11 +599,21 @@ function confidencePct(v: AnalysisVersion | null): number {
 .snapshot-grid  { display: grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
 .snapshot-item  { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 10px; padding: 10px 12px; }
 .snapshot-key   { font-size: 11px; font-weight: 600; color: #6a819a; margin-bottom: 3px; }
-.snapshot-val   { font-size: 13px; font-weight: 700; font-family: monospace; color: #173451; }
+.snapshot-val   { font-size: 13px; font-weight: 700; color: #173451; word-break: break-all; }
 
 .resource-list { display: flex; flex-direction: column; gap: 8px; margin-top: 12px; font-size: 13px; }
 .resource-row  { display: flex; justify-content: space-between; align-items: center; }
 .resource-row code { font-family: monospace; font-size: 12px; font-weight: 600; color: #173451; }
+
+/* 스냅샷 타임라인 */
+.timeline-list  { display: flex; flex-direction: column; gap: 6px; }
+.timeline-event { display: flex; align-items: flex-start; gap: 10px; }
+.timeline-dot   { width: 8px; height: 8px; border-radius: 50%; background: #ff7a00; flex-shrink: 0; margin-top: 5px; }
+.timeline-body  { display: flex; flex-wrap: wrap; align-items: center; gap: 6px; font-size: 12px; }
+.timeline-type  { font-weight: 700; color: #173451; }
+.timeline-source { background: #f7fafd; border: 1px solid #d6e3f2; border-radius: 6px; padding: 1px 7px; }
+.timeline-note  { font-style: italic; }
+.timeline-time  { margin-left: auto; white-space: nowrap; }
 
 /* 신호 */
 .signal-card  { padding: 20px 22px; }

--- a/incident-agent/src/main/java/com/example/incident/agent/analysis/AnalysisInputBuilder.java
+++ b/incident-agent/src/main/java/com/example/incident/agent/analysis/AnalysisInputBuilder.java
@@ -47,7 +47,12 @@ public class AnalysisInputBuilder {
 
         if (incident.getCurrentStateJsonb() != null) {
             try {
-                root.set("signals", objectMapper.readTree(incident.getCurrentStateJsonb()));
+                com.fasterxml.jackson.databind.JsonNode stateNode =
+                        objectMapper.readTree(incident.getCurrentStateJsonb());
+                root.set("signals", stateNode);
+                if (stateNode.has("timeline")) {
+                    root.set("timeline", stateNode.get("timeline"));
+                }
             } catch (JsonProcessingException e) {
                 root.put("signals", incident.getCurrentStateJsonb());
             }

--- a/incident-agent/src/main/java/com/example/incident/agent/prompt/SystemPromptBuilder.java
+++ b/incident-agent/src/main/java/com/example/incident/agent/prompt/SystemPromptBuilder.java
@@ -13,6 +13,13 @@ public class SystemPromptBuilder {
             - detector가 제공한 incidentTypeCandidate와 signals를 존중합니다.
             - 확정할 수 없는 내용은 "~로 보입니다", "~가능성이 있습니다" 형태로 표현합니다.
 
+            ## confidence 산정 기준
+            아래 조건을 기준으로 confidence(0.0~1.0)를 결정합니다.
+            - 0.9 이상: 탐지 신호가 명확하고 timeline 이벤트가 3개 이상이며 상태 불일치가 구체적으로 확인됨
+            - 0.7~0.9: 주요 신호는 있으나 timeline 이벤트가 2개 이하이거나 일부 상태 정보가 불명확함
+            - 0.7 미만: 신호가 약하거나 timeline 정보가 부족하거나 여러 원인 중 하나일 가능성이 높음
+            - incidentType을 reclassify해야 한다고 판단되는 경우 confidence는 0.6을 초과하지 않습니다
+
             ## 출력 규칙
             - 반드시 아래 JSON 형식으로만 응답합니다. 다른 텍스트(설명, 마크다운 코드블록 등)를 포함하지 않습니다.
             - PII(이메일, 전화번호, 이름, 카드 정보)를 새로 유추하거나 복원하지 않습니다.

--- a/incident-detector/src/main/java/com/example/incident/detector/rules/DuplicatePaymentRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/DuplicatePaymentRule.java
@@ -83,13 +83,24 @@ public class DuplicatePaymentRule {
 
     private String buildStateJson(PaymentEventMessage event) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "paymentId", String.valueOf(event.paymentId()),
-                    "bookingId", String.valueOf(event.bookingId()),
-                    "fromStatus", orEmpty(event.fromStatus()),
-                    "toStatus", orEmpty(event.toStatus()),
-                    "occurredAt", orEmpty(event.occurredAt())
-            ));
+            java.util.List<Map<String, String>> timeline = java.util.List.of(
+                    Map.of("eventType", "PAYMENT_CONFIRMED_FIRST",
+                            "occurredAt", orEmpty(event.occurredAt()),
+                            "source", "payment",
+                            "note", "first confirmation recorded in Redis"),
+                    Map.of("eventType", "PAYMENT_CONFIRMED_DUPLICATE",
+                            "occurredAt", orEmpty(event.occurredAt()),
+                            "source", "payment",
+                            "note", "duplicate confirmation detected for same bookingId")
+            );
+            java.util.LinkedHashMap<String, Object> state = new java.util.LinkedHashMap<>();
+            state.put("paymentId", String.valueOf(event.paymentId()));
+            state.put("bookingId", String.valueOf(event.bookingId()));
+            state.put("fromStatus", orEmpty(event.fromStatus()));
+            state.put("toStatus", orEmpty(event.toStatus()));
+            state.put("occurredAt", orEmpty(event.occurredAt()));
+            state.put("timeline", timeline);
+            return objectMapper.writeValueAsString(state);
         } catch (JsonProcessingException e) {
             return "{}";
         }

--- a/incident-detector/src/main/java/com/example/incident/detector/rules/GhostOrderRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/GhostOrderRule.java
@@ -142,12 +142,22 @@ public class GhostOrderRule {
 
     private String buildCurrentStateJson(PendingCorrelation pending) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "bookingId", pending.getKeyValue(),
-                    "triggeredAt", pending.getTriggeredAt().toString(),
-                    "deadlineAt", pending.getDeadlineAt().toString(),
-                    "extraJson", orEmpty(pending.getExtraJsonb())
-            ));
+            java.util.List<Map<String, String>> timeline = java.util.List.of(
+                    Map.of("eventType", "PAYMENT_CONFIRMED",
+                            "occurredAt", pending.getTriggeredAt().toString(),
+                            "source", "payment"),
+                    Map.of("eventType", "BOOKING_CONFIRMED_MISSING",
+                            "occurredAt", pending.getDeadlineAt().toString(),
+                            "source", "detector",
+                            "note", "deadline exceeded without booking.confirmed")
+            );
+            java.util.LinkedHashMap<String, Object> state = new java.util.LinkedHashMap<>();
+            state.put("bookingId", pending.getKeyValue());
+            state.put("triggeredAt", pending.getTriggeredAt().toString());
+            state.put("deadlineAt", pending.getDeadlineAt().toString());
+            state.put("extraJson", orEmpty(pending.getExtraJsonb()));
+            state.put("timeline", timeline);
+            return objectMapper.writeValueAsString(state);
         } catch (JsonProcessingException e) {
             return "{}";
         }

--- a/incident-detector/src/main/java/com/example/incident/detector/rules/UnconfirmedPaymentRule.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/rules/UnconfirmedPaymentRule.java
@@ -76,7 +76,7 @@ public class UnconfirmedPaymentRule {
         IncidentCreateCommand cmd = new IncidentCreateCommand(
                 "UNCONFIRMED_PAYMENT",
                 pending.getKeyValue(),
-                "medium",
+                "high",
                 "UNCONFIRMED_PAYMENT_NO_CONFIRM",
                 buildCurrentStateJson(pending),
                 UUID.fromString(pending.getKeyValue()),
@@ -164,12 +164,22 @@ public class UnconfirmedPaymentRule {
 
     private String buildCurrentStateJson(PendingCorrelation pending) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "paymentId", pending.getKeyValue(),
-                    "triggeredAt", pending.getTriggeredAt().toString(),
-                    "deadlineAt", pending.getDeadlineAt().toString(),
-                    "extraJson", orEmpty(pending.getExtraJsonb())
-            ));
+            java.util.List<Map<String, String>> timeline = java.util.List.of(
+                    Map.of("eventType", orEmpty(pending.getTriggerEventType()),
+                            "occurredAt", pending.getTriggeredAt().toString(),
+                            "source", "payment"),
+                    Map.of("eventType", "PAYMENT_CONFIRMED_MISSING",
+                            "occurredAt", pending.getDeadlineAt().toString(),
+                            "source", "detector",
+                            "note", "deadline exceeded without PAYMENT_CONFIRMED")
+            );
+            java.util.LinkedHashMap<String, Object> state = new java.util.LinkedHashMap<>();
+            state.put("paymentId", pending.getKeyValue());
+            state.put("triggeredAt", pending.getTriggeredAt().toString());
+            state.put("deadlineAt", pending.getDeadlineAt().toString());
+            state.put("extraJson", orEmpty(pending.getExtraJsonb()));
+            state.put("timeline", timeline);
+            return objectMapper.writeValueAsString(state);
         } catch (JsonProcessingException e) {
             return "{}";
         }

--- a/incident-detector/src/main/java/com/example/incident/detector/zombie/ZombieHoldCheckScheduler.java
+++ b/incident-detector/src/main/java/com/example/incident/detector/zombie/ZombieHoldCheckScheduler.java
@@ -74,12 +74,22 @@ public class ZombieHoldCheckScheduler {
 
     private String buildStateJson(ZombieCandidate candidate) {
         try {
-            return objectMapper.writeValueAsString(Map.of(
-                    "bookingId", candidate.getBookingId().toString(),
-                    "endedEventType", orEmpty(candidate.getEndedEventType()),
-                    "endedAt", candidate.getEndedAt().toString(),
-                    "checkAfterAt", candidate.getCheckAfterAt().toString()
-            ));
+            java.util.List<Map<String, String>> timeline = java.util.List.of(
+                    Map.of("eventType", orEmpty(candidate.getEndedEventType()),
+                            "occurredAt", candidate.getEndedAt().toString(),
+                            "source", "ticketing"),
+                    Map.of("eventType", "ZOMBIE_HOLD_DETECTED",
+                            "occurredAt", candidate.getCheckAfterAt().toString(),
+                            "source", "detector",
+                            "note", "Redis hold key still present after grace period")
+            );
+            java.util.LinkedHashMap<String, Object> state = new java.util.LinkedHashMap<>();
+            state.put("bookingId", candidate.getBookingId().toString());
+            state.put("endedEventType", orEmpty(candidate.getEndedEventType()));
+            state.put("endedAt", candidate.getEndedAt().toString());
+            state.put("checkAfterAt", candidate.getCheckAfterAt().toString());
+            state.put("timeline", timeline);
+            return objectMapper.writeValueAsString(state);
         } catch (JsonProcessingException e) {
             return "{}";
         }

--- a/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/domain/Payment.java
+++ b/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/domain/Payment.java
@@ -50,6 +50,12 @@ public class Payment {
     @Column(name = "booking_id", columnDefinition = "uuid", nullable = false)
     private UUID bookingId;
 
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "schedule_id")
+    private Long scheduleId;
+
     // 결제 당시 PG로 보낸 상품명 저장용
     @Column(name = "order_name")
     private String orderName;

--- a/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/service/PaymentEventRecorder.java
+++ b/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/service/PaymentEventRecorder.java
@@ -75,6 +75,8 @@ public class PaymentEventRecorder {
         payload.put("amount", payment.getAmount() != null ? payment.getAmount() : 0);
         payload.put("pgOrderId", safe(payment.getPgOrderId()));
         payload.put("pgPaymentKey", safe(payment.getPgPaymentKey()));
+        if (payment.getUserId() != null)    payload.put("userId", payment.getUserId());
+        if (payment.getScheduleId() != null) payload.put("scheduleId", payment.getScheduleId());
         if (metadata != null && !metadata.isEmpty()) {
             for (Map.Entry<String, Object> entry : metadata.entrySet()) {
                 if (entry.getValue() != null) {

--- a/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/service/PaymentService.java
+++ b/payment-service/src/main/java/com/example/SKALA_Mini_Project_1/modules/payments/service/PaymentService.java
@@ -111,6 +111,8 @@ public PaymentCreateResponse createPayment(UUID bookingId, Long userId) {
 
                 Payment payment = new Payment();
                 payment.setBookingId(bookingId);
+                payment.setUserId(userId);
+                payment.setScheduleId(bookingContext.scheduleId());
                 payment.setAmount(amount);
                 payment.setStatus(PaymentStatus.PENDING);
                 payment.setCreatedAt(now);


### PR DESCRIPTION
feat: 결제 운영 대시보드 개선 — LLM 신뢰도 기준·타임라인·리소스 추적 강화

## Summary

### LLM 분석 품질 개선
- SystemPromptBuilder에 confidence 산정 기준 추가 (0.9 이상 / 0.7~0.9 / 0.7 미만 / reclassify 시 0.6 이하)
- 4개 탐지 룰(GhostOrder, UnconfirmedPayment, DuplicatePayment, ZombieHold)의 currentStateJsonb에 timeline 필드 추가
- AnalysisInputBuilder에서 currentStateJsonb 내 timeline을 꺼내 LLM 입력에 별도 필드로 포함
- UnconfirmedPaymentRule severity medium → high 수정 (설계 문서 기준 반영)

### 운영자 리소스 추적 개선 (userId / scheduleId)
- payment.payments 테이블에 user_id, schedule_id 컬럼 추가
- Payment 엔티티에 userId, scheduleId 필드 추가
- createPayment 시 bookingContext에서 userId, scheduleId를 받아 Payment에 저장
- PaymentEventRecorder.buildPayloadJson에 userId, scheduleId 포함 → Kafka 이벤트로 전파
- incident-detector가 payloadJson에서 userId, scheduleId 파싱 가능해져 인시던트에 리소스 정보 기록
- DB 마이그레이션 파일 추가 (005_add_user_schedule_to_payments.sql)

### 운영자 대시보드 UI 개선
- 현재 상태 스냅샷 패널: extraJson 중첩 JSON 제거 → 내부 필드를 개별 카드로 펼쳐서 표시
- 현재 상태 스냅샷 패널: timeline 배열을 별도 이벤트 흐름 섹션으로 분리 렌더링
- 현재 상태 스냅샷 패널: ISO 타임스탬프를 한국어 날짜 포맷으로 변환
- 관련 리소스 패널과 스냅샷 간 중복 필드(paymentId, bookingId 등) 제거

## Background
기존 confidence 값은 LLM이 기준 없이 자기 평가로 출력하는 구조였고,
LLM 입력에 타임라인 이벤트가 없어 판단 근거가 currentStateJsonb 스냅샷에만 의존하고 있었음.
또한 payment 이벤트 payloadJson에 userId/scheduleId가 누락되어 운영자 대시보드의
관련 리소스 패널이 항상 비어 있는 문제가 있었음.

## Changes

| 파일 | 변경 내용 |
|------|-----------|
| `incident-agent/.../SystemPromptBuilder.java` | confidence 산정 기준 추가 |
| `incident-agent/.../AnalysisInputBuilder.java` | LLM 입력에 timeline 필드 분리 포함 |
| `incident-detector/.../GhostOrderRule.java` | currentStateJsonb에 timeline 추가 |
| `incident-detector/.../UnconfirmedPaymentRule.java` | timeline 추가, severity medium → high |
| `incident-detector/.../DuplicatePaymentRule.java` | timeline 추가 |
| `incident-detector/.../ZombieHoldCheckScheduler.java` | timeline 추가 |
| `payment-service/.../Payment.java` | userId, scheduleId 필드 추가 |
| `payment-service/.../PaymentService.java` | createPayment 시 userId, scheduleId 저장 |
| `payment-service/.../PaymentEventRecorder.java` | payloadJson에 userId, scheduleId 포함 |
| `fairline_k8s/sql/rds/001_service_schemas.sql` | payments 테이블 컬럼 추가 |
| `fairline_k8s/sql/rds/005_add_user_schedule_to_payments.sql` | ALTER TABLE 마이그레이션 추가 |
| `frontend/.../OpsIncidentDetailPage.vue` | 스냅샷 패널 평탄화 및 타임라인 렌더링 |